### PR TITLE
Add first-class AGENTS.md adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- N/A
+- First-class AGENTS.md SpecAdapter (AAIF / Linux Foundation standard). Detects
+  `AGENTS.md` / `AGENT.md` at the repo root or nested, splits on markdown
+  headings into knowledge SpecBlocks, and is marked stable (not experimental).
 
 ### Changed
 - N/A

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ print(bundle.tldr)
 
 | Feature | Description |
 |---------|-------------|
-| **🔌 Multi-Framework Adapters** | Parse specs from Kiro, SpecKit, Tessl, Claude Code, Cursor, Codex, Factory, Warp, Gemini CLI |
+| **🔌 Multi-Framework Adapters** | Parse specs from Kiro, SpecKit, Tessl, Claude Code, Cursor, and AGENTS.md (AAIF standard used by Codex, Factory, Warp, and others) |
 | **🧠 Intelligent Memory** | Vector-based semantic search with LanceDB, ChromaDB, Qdrant, or AgentVectorDB |
 | **📊 SpecImpact Graph** | Bidirectional relationships between specs, code, and tests |
 | **⏱️ SpecDiff Timeline** | Track spec evolution, detect drift, find contradictions |
@@ -113,7 +113,7 @@ print(bundle.tldr)
 | Feature | Description |
 |---------|-------------|
 | **☁️ Cloud Embeddings** | Support for OpenAI, Google, Together AI embedding providers |
-| **📜 Coding Guidelines** | Aggregate and view guidelines from Kiro steering, CLAUDE.md, .cursorrules |
+| **📜 Coding Guidelines** | Aggregate and view guidelines from Kiro steering, CLAUDE.md, AGENTS.md, .cursorrules |
 | **🔄 Spec Lifecycle** | Prune stale specs, generate specs from code, compress verbose specs |
 | **🔍 Kiro Session Search** | Index and search Kiro chat sessions for context |
 | **⚙️ Kiro Config Indexer** | Index hooks, steering files, and MCP configurations |
@@ -444,12 +444,15 @@ Or deploy to GitHub Pages with the dashboard action:
 
 | Framework | Adapter | File Patterns |
 |-----------|---------|---------------|
+| **AGENTS.md** (AAIF) | `agents.md` | `**/AGENTS.md`, `**/AGENT.md` |
 | Claude Code | `claude` | `Claude.md`, `CLAUDE.md` |
 | Cursor | `cursor` | `cursor.json`, `.cursorrules` |
-| Codex | `codex` | `.codex/**/*.md` |
-| Factory | `factory` | `.factory/**/*.yaml` |
-| Warp | `warp` | `.warp/**/*.md` |
-| Gemini CLI | `gemini` | `GEMINI.md`, `.gemini/**/*.md` |
+
+Codex, Factory, Warp, Cursor, OpenCode, Amp, and Aider consume **AGENTS.md**
+(the AAIF / Linux Foundation standard). SpecMem indexes those files through the
+AGENTS.md adapter rather than invented vendor trees such as `.codex/**/*.md`,
+`.factory/**/*.yaml`, or `.warp/**`. Gemini CLI's `GEMINI.md` is picked up by
+the guidelines scanner, not a separate SpecAdapter.
 
 ---
 

--- a/docs/api/adapters.md
+++ b/docs/api/adapters.md
@@ -34,6 +34,21 @@ if adapter.can_parse(Path(".kiro/specs/auth/requirements.md")):
 specs = adapter.parse_directory(Path(".kiro/specs"))
 ```
 
+### AGENTS.md Adapter
+
+```python
+from specmem.adapters.agents import AgentsAdapter
+
+adapter = AgentsAdapter()
+
+# Detect AGENTS.md at the repo root or nested
+if adapter.detect("."):
+    specs = adapter.load(".")
+```
+
+Parses `AGENTS.md` / `AGENT.md` (AAIF standard). Codex, Factory, Warp, and
+other tools that consume AGENTS.md are covered by this adapter.
+
 ### Cursor Adapter
 
 ```python

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- N/A
+- First-class AGENTS.md SpecAdapter (AAIF / Linux Foundation standard). Detects
+  `AGENTS.md` / `AGENT.md` at the repo root or nested, splits on markdown
+  headings into knowledge SpecBlocks, and is marked stable (not experimental).
 
 ### Changed
 - N/A

--- a/docs/user-guide/adapters.md
+++ b/docs/user-guide/adapters.md
@@ -16,12 +16,14 @@ SpecMem adapters parse specifications from various AI coding agent frameworks.
 
 | Framework | Adapter | File Patterns |
 |-----------|---------|---------------|
+| **AGENTS.md** (AAIF) | `agents.md` | `**/AGENTS.md`, `**/AGENT.md` |
 | Claude Code | `claude` | `Claude.md`, `CLAUDE.md` |
 | Cursor | `cursor` | `cursor.json`, `.cursorrules` |
-| Codex | `codex` | `.codex/**/*.md` |
-| Factory | `factory` | `.factory/**/*.yaml` |
-| Warp | `warp` | `.warp/**/*.md` |
-| Gemini CLI | `gemini` | `GEMINI.md`, `.gemini/**/*.md` |
+
+Codex, Factory, Warp, Cursor, OpenCode, Amp, and Aider consume **AGENTS.md**.
+SpecMem indexes those files through the AGENTS.md adapter rather than invented
+vendor trees (`.codex/**/*.md`, `.factory/**/*.yaml`, `.warp/**`). Gemini CLI's
+`GEMINI.md` is found by the guidelines scanner, not a separate SpecAdapter.
 
 ---
 
@@ -256,100 +258,48 @@ rules_file = ".cursorrules"
 
 ---
 
-## Codex Adapter
+## AGENTS.md Adapter
 
-Parses OpenAI Codex specifications.
-
-### Structure
-
-```
-.codex/
-├── specs/
-│   └── feature.md
-└── config.json
-```
-
-### Configuration
-
-```toml
-[adapters]
-codex = true
-
-[adapters.codex]
-spec_dir = ".codex"
-```
-
----
-
-## Factory Adapter
-
-Parses Factory's YAML-based workflow specifications.
-
-### Structure
-
-```
-.factory/
-├── workflows/
-│   └── build.yaml
-└── config.yaml
-```
-
-### Configuration
-
-```toml
-[adapters]
-factory = true
-
-[adapters.factory]
-spec_dir = ".factory"
-```
-
----
-
-## Warp Adapter
-
-Parses Warp terminal's markdown specifications.
-
-### Structure
-
-```
-.warp/
-├── specs/
-│   └── commands.md
-└── config.toml
-```
-
-### Configuration
-
-```toml
-[adapters]
-warp = true
-
-[adapters.warp]
-spec_dir = ".warp"
-```
-
----
-
-## Gemini CLI Adapter
-
-Parses Google Gemini CLI specifications.
+Parses the AAIF / Linux Foundation `AGENTS.md` standard. This is a **stable**
+adapter (not experimental). Codex, Factory, Warp, Cursor, OpenCode, Amp, and
+Aider all consume these files.
 
 ### Files
 
-- `GEMINI.md` - Project context and rules
-- `.gemini/**/*.md` - Additional specifications
+- `AGENTS.md` or `Agents.md` — official filename (repo root or nested)
+- `AGENT.md` or `Agent.md` — aliases also accepted by the guidelines scanner
+
+Closest-file-wins: a nested `AGENTS.md` applies to that subtree.
+
+### Example
+
+```markdown
+# Project Rules
+
+Keep pull requests focused and scoped to one change.
+
+## Testing
+
+Run unit tests before opening a PR.
+
+## Style
+
+Prefer typed Python.
+```
+
+Heading sections become knowledge SpecBlocks tagged `agents` / `agents.md`
+plus a slug of the heading. A file with no headings becomes one pinned block.
 
 ### Configuration
 
 ```toml
 [adapters]
-gemini = true
-
-[adapters.gemini]
-files = ["GEMINI.md"]
-spec_dir = ".gemini"
+# Auto-discovered; no extra config required
 ```
+
+There are no first-class Codex, Factory, Warp, or Gemini SpecAdapters. Those
+tools are covered by AGENTS.md (and, for Gemini CLI, the guidelines scanner's
+`GEMINI.md` support). Do not invent `.codex/`, `.factory/`, or `.warp/` trees.
 
 ---
 
@@ -367,10 +317,6 @@ tessl = true
 # Commercial agents
 claude = true
 cursor = true
-codex = false
-factory = false
-warp = false
-gemini = false
 ```
 
 When scanning, SpecMem merges specs from all enabled adapters:
@@ -401,7 +347,7 @@ When specs conflict, priority is determined by:
 [adapters]
 # Framework priority (first = highest)
 # Spec-Driven Development frameworks take precedence
-priority = ["kiro", "speckit", "tessl", "claude", "cursor", "codex", "factory", "warp", "gemini"]
+priority = ["kiro", "speckit", "tessl", "agents.md", "claude", "cursor"]
 ```
 
 ## Custom Adapters

--- a/specmem/adapters/agents.py
+++ b/specmem/adapters/agents.py
@@ -1,0 +1,212 @@
+"""AGENTS.md adapter for SpecMem.
+
+AGENTS.md is the AAIF / Linux Foundation standard for agent instructions:
+plain Markdown at the repo root or nested, with closest-file-wins. Codex,
+Cursor, Factory, Warp, OpenCode, Amp, Aider, and others consume it.
+
+This adapter handles the official filename plus the aliases already used
+by the guidelines scanner:
+- AGENTS.md / Agents.md
+- AGENT.md / Agent.md
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from specmem.adapters.base import SpecAdapter
+from specmem.core.specir import SpecBlock, SpecStatus, SpecType
+
+
+logger = logging.getLogger(__name__)
+
+
+class AgentsAdapter(SpecAdapter):
+    """Stable adapter for AGENTS.md agent-instruction files.
+
+    Detects and parses:
+    - AGENTS.md / Agents.md (official AAIF filename)
+    - AGENT.md / Agent.md (guidelines-scanner aliases)
+    """
+
+    FILENAMES = frozenset({"AGENTS.md", "Agents.md", "AGENT.md", "Agent.md"})
+    SKIP_DIRS = frozenset(
+        {
+            ".git",
+            ".venv",
+            "venv",
+            "node_modules",
+            "__pycache__",
+            ".tox",
+            ".mypy_cache",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".specmem",
+            "dist",
+            "build",
+        }
+    )
+
+    @property
+    def name(self) -> str:
+        return "AGENTS.md"
+
+    def is_experimental(self) -> bool:
+        """AGENTS.md is a stable standard, not an experimental adapter."""
+        return False
+
+    def detect(self, repo_path: str) -> bool:
+        """Return True if any AGENTS.md (or alias) exists in the repository."""
+        path = Path(repo_path)
+        if not path.exists():
+            return False
+        return bool(self._find_files(path))
+
+    def load(self, repo_path: str) -> list[SpecBlock]:
+        """Load and parse all AGENTS.md files into SpecBlocks."""
+        blocks: list[SpecBlock] = []
+        path = Path(repo_path)
+
+        if not path.exists():
+            return blocks
+
+        for file_path in self._find_files(path):
+            try:
+                file_blocks = self._parse_file(file_path)
+                blocks.extend(file_blocks)
+            except Exception as e:
+                logger.warning(f"Failed to parse AGENTS.md file {file_path}: {e}")
+
+        logger.info(f"Loaded {len(blocks)} SpecBlocks from AGENTS.md files")
+        return blocks
+
+    def _find_files(self, repo_path: Path) -> list[Path]:
+        """Find AGENTS.md files, skipping junk directories and duplicates."""
+        seen: set[Path] = set()
+        found: list[Path] = []
+        self._walk(repo_path, repo_path, seen, found)
+        return found
+
+    def _walk(
+        self,
+        root: Path,
+        directory: Path,
+        seen: set[Path],
+        found: list[Path],
+    ) -> None:
+        try:
+            entries = list(directory.iterdir())
+        except OSError as e:
+            logger.warning(f"Failed to read directory {directory}: {e}")
+            return
+
+        for entry in entries:
+            try:
+                if entry.is_dir():
+                    if entry.name in self.SKIP_DIRS:
+                        continue
+                    self._walk(root, entry, seen, found)
+                elif entry.is_file() and entry.name in self.FILENAMES:
+                    key = entry.resolve()
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    found.append(entry)
+            except OSError as e:
+                logger.warning(f"Failed to inspect {entry}: {e}")
+
+    def _parse_file(self, file_path: Path) -> list[SpecBlock]:
+        """Parse a single AGENTS.md file into SpecBlocks."""
+        blocks: list[SpecBlock] = []
+        source = str(file_path)
+
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"Failed to read {file_path}: {e}")
+            return blocks
+
+        if not content.strip():
+            return blocks
+
+        sections = self._extract_sections(content)
+
+        if sections:
+            for section in sections:
+                tags = ["agents", "agents.md"]
+                if section["title"]:
+                    tags.append(self._slug(section["title"]))
+
+                blocks.append(
+                    SpecBlock(
+                        id=SpecBlock.generate_id(source, section["content"]),
+                        type=SpecType.KNOWLEDGE,
+                        text=section["content"],
+                        source=source,
+                        status=SpecStatus.ACTIVE,
+                        tags=tags,
+                        links=[],
+                        pinned=False,
+                    )
+                )
+        elif re.search(r"^#{1,3}\s+.+", content, re.MULTILINE):
+            # Headings exist but no usable body text — skip empty-ish file
+            return blocks
+        else:
+            blocks.append(
+                SpecBlock(
+                    id=SpecBlock.generate_id(source, content),
+                    type=SpecType.KNOWLEDGE,
+                    text=content,
+                    source=source,
+                    status=SpecStatus.ACTIVE,
+                    tags=["agents", "agents.md"],
+                    links=[],
+                    pinned=True,  # Whole-file agent context is important
+                )
+            )
+
+        return blocks
+
+    def _extract_sections(self, content: str) -> list[dict[str, str]]:
+        """Split content on markdown # / ## / ### headings.
+
+        Returns an empty list when no headings are present so the caller
+        can emit a single whole-file SpecBlock.
+        """
+        sections: list[dict[str, str]] = []
+        header_pattern = r"^(#{1,3})\s+(.+)$"
+
+        current_section: dict[str, str] | None = None
+        current_content: list[str] = []
+
+        for line in content.split("\n"):
+            header_match = re.match(header_pattern, line)
+            if header_match:
+                if current_section is not None:
+                    current_section["content"] = "\n".join(current_content).strip()
+                    if current_section["content"]:
+                        sections.append(current_section)
+
+                current_section = {
+                    "title": header_match.group(2).strip(),
+                    "content": "",
+                }
+                current_content = []
+            else:
+                current_content.append(line)
+
+        if current_section is not None:
+            current_section["content"] = "\n".join(current_content).strip()
+            if current_section["content"]:
+                sections.append(current_section)
+
+        return sections
+
+    @staticmethod
+    def _slug(title: str) -> str:
+        """Turn a heading into a short tag slug."""
+        slug = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+        return slug[:30]

--- a/tests/property/test_adapter_props.py
+++ b/tests/property/test_adapter_props.py
@@ -965,6 +965,7 @@ class TestAdapterRegistration:
         assert "speckit" in adapter_names
         assert "cursor" in adapter_names
         assert "claude" in adapter_names
+        assert "agents.md" in adapter_names
 
     def test_experimental_adapters_marked(self) -> None:
         """Experimental adapters should be properly marked."""
@@ -979,8 +980,9 @@ class TestAdapterRegistration:
         assert "cursor" in experimental_names
         assert "claude" in experimental_names
 
-        # Kiro should NOT be experimental
+        # Kiro and AGENTS.md should NOT be experimental
         assert "kiro" not in experimental_names
+        assert "agents.md" not in experimental_names
 
     def test_get_adapter_by_name(self) -> None:
         """Should be able to get adapter by name."""
@@ -996,6 +998,11 @@ class TestAdapterRegistration:
         assert kiro.name == "Kiro"
         assert kiro.is_experimental() is False
 
+        agents = get_adapter("agents.md")
+        assert agents is not None
+        assert agents.name == "AGENTS.md"
+        assert agents.is_experimental() is False
+
     def test_get_adapter_case_insensitive(self) -> None:
         """Adapter lookup should be case-insensitive."""
         from specmem.adapters import get_adapter
@@ -1003,3 +1010,5 @@ class TestAdapterRegistration:
         assert get_adapter("TESSL") is not None
         assert get_adapter("Tessl") is not None
         assert get_adapter("tessl") is not None
+        assert get_adapter("AGENTS.md") is not None
+        assert get_adapter("agents.md") is not None

--- a/tests/unit/test_agents_adapter.py
+++ b/tests/unit/test_agents_adapter.py
@@ -1,0 +1,246 @@
+"""Unit tests for AgentsAdapter.
+
+Tests detection, heading split, aliases, and error handling for AGENTS.md.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from specmem.adapters.agents import AgentsAdapter
+from specmem.core.specir import SpecStatus, SpecType
+
+
+@pytest.fixture
+def adapter() -> AgentsAdapter:
+    """Create an AgentsAdapter instance."""
+    return AgentsAdapter()
+
+
+class TestAgentsAdapterDetection:
+    """Tests for AgentsAdapter.detect()"""
+
+    def test_detect_root_file(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should detect AGENTS.md at the repository root."""
+        (tmp_path / "AGENTS.md").write_text("# Agent rules\n\nKeep changes scoped.")
+
+        assert adapter.detect(str(tmp_path)) is True
+
+    def test_detect_nested_file(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should detect nested AGENTS.md files."""
+        nested = tmp_path / "packages" / "api"
+        nested.mkdir(parents=True)
+        (nested / "AGENTS.md").write_text("# Package rules\n\nUse typed APIs.")
+
+        assert adapter.detect(str(tmp_path)) is True
+
+    def test_detect_agent_md_alias(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should detect AGENT.md alias used by the guidelines scanner."""
+        (tmp_path / "AGENT.md").write_text("# Alias\n\nFollow these rules.")
+
+        assert adapter.detect(str(tmp_path)) is True
+
+    @pytest.mark.parametrize("filename", ["Agents.md", "Agent.md"])
+    def test_detect_case_aliases(
+        self, adapter: AgentsAdapter, tmp_path: Path, filename: str
+    ) -> None:
+        """Should detect Agents.md and Agent.md aliases."""
+        (tmp_path / filename).write_text("# Alias\n\nFollow these rules.")
+
+        assert adapter.detect(str(tmp_path)) is True
+
+    def test_detect_empty_repo(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should not false-positive on an empty repository."""
+        assert adapter.detect(str(tmp_path)) is False
+
+    def test_detect_unrelated_markdown(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should not detect README.md or other markdown files."""
+        (tmp_path / "README.md").write_text("# Readme\n\nHello.")
+
+        assert adapter.detect(str(tmp_path)) is False
+
+    def test_detect_missing_repo(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should return False when the repository path does not exist."""
+        assert adapter.detect(str(tmp_path / "does-not-exist")) is False
+
+    def test_detect_ignores_junk_dirs(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should ignore AGENTS.md inside node_modules, .git, and .venv."""
+        for junk in ("node_modules", ".git", ".venv"):
+            junk_dir = tmp_path / junk / "pkg"
+            junk_dir.mkdir(parents=True)
+            (junk_dir / "AGENTS.md").write_text("# Junk\n\nShould be ignored.")
+
+        assert adapter.detect(str(tmp_path)) is False
+
+
+class TestAgentsAdapterLoad:
+    """Tests for AgentsAdapter.load()"""
+
+    def test_load_sections_from_headings(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should split AGENTS.md on markdown headings into SpecBlocks."""
+        (tmp_path / "AGENTS.md").write_text(
+            """# Project Rules
+
+Keep pull requests focused.
+
+## Testing
+
+Run unit tests before opening a PR.
+
+### Style
+
+Prefer typed Python.
+"""
+        )
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert len(blocks) == 3
+        assert all(b.type == SpecType.KNOWLEDGE for b in blocks)
+        assert all(b.status == SpecStatus.ACTIVE for b in blocks)
+        assert all(b.pinned is False for b in blocks)
+        assert all("agents" in b.tags and "agents.md" in b.tags for b in blocks)
+
+        texts = [b.text for b in blocks]
+        assert any("Keep pull requests focused." in text for text in texts)
+        assert any("Run unit tests before opening a PR." in text for text in texts)
+        assert any("Prefer typed Python." in text for text in texts)
+
+        all_tags = [tag for b in blocks for tag in b.tags]
+        assert "project_rules" in all_tags
+        assert "testing" in all_tags
+        assert "style" in all_tags
+
+    def test_load_whole_file_without_headings(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should create one pinned SpecBlock when the file has no headings."""
+        content = "Always use typed Python.\nKeep diffs small.\n"
+        (tmp_path / "AGENTS.md").write_text(content)
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert len(blocks) == 1
+        block = blocks[0]
+        assert block.type == SpecType.KNOWLEDGE
+        assert block.status == SpecStatus.ACTIVE
+        assert block.pinned is True
+        assert block.text == content
+        assert block.tags == ["agents", "agents.md"]
+        assert "AGENTS.md" in block.source
+
+    def test_load_nested_file(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should load nested AGENTS.md files."""
+        nested = tmp_path / "apps" / "web"
+        nested.mkdir(parents=True)
+        (nested / "AGENTS.md").write_text("# Frontend\n\nUse the design system.")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert len(blocks) == 1
+        assert "Use the design system." in blocks[0].text
+        assert str(nested / "AGENTS.md") == blocks[0].source
+
+    def test_load_agent_md_alias(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should parse AGENT.md the same way as AGENTS.md."""
+        (tmp_path / "AGENT.md").write_text("# Alias\n\nTreat this as agent guidance.")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert len(blocks) == 1
+        assert blocks[0].type == SpecType.KNOWLEDGE
+        assert "Treat this as agent guidance." in blocks[0].text
+        assert "agents" in blocks[0].tags
+
+    def test_load_deduplicates_paths(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should not emit duplicate blocks for the same file."""
+        (tmp_path / "AGENTS.md").write_text("# Rules\n\nOne file only.")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert len(blocks) == 1
+
+    def test_load_skips_missing_repo(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should return an empty list when the repository is missing."""
+        blocks = adapter.load(str(tmp_path / "missing"))
+        assert blocks == []
+
+    def test_load_skips_empty_file(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should skip empty files without creating SpecBlocks."""
+        (tmp_path / "AGENTS.md").write_text("")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert blocks == []
+
+    def test_load_skips_whitespace_only_file(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should skip whitespace-only files."""
+        (tmp_path / "AGENTS.md").write_text("   \n\n  \n")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert blocks == []
+
+    def test_load_skips_heading_only_sections(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should skip headings that have no body content."""
+        (tmp_path / "AGENTS.md").write_text("# Title\n\n# Another\n")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert blocks == []
+
+    def test_load_skips_unreadable_file(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should warn and continue when a file cannot be read."""
+        (tmp_path / "AGENTS.md").write_text("# Rules\n\nImportant context.")
+        original = Path.read_text
+
+        def boom(self: Path, *args: object, **kwargs: object) -> str:
+            if self.name in AgentsAdapter.FILENAMES:
+                raise OSError("permission denied")
+            return original(self, *args, **kwargs)
+
+        with patch.object(Path, "read_text", boom):
+            blocks = adapter.load(str(tmp_path))
+
+        assert blocks == []
+
+    def test_load_skips_junk_dirs(self, adapter: AgentsAdapter, tmp_path: Path) -> None:
+        """Should not load AGENTS.md from ignored directories."""
+        junk = tmp_path / "node_modules" / "lib"
+        junk.mkdir(parents=True)
+        (junk / "AGENTS.md").write_text("# Vendor\n\nIgnore me.")
+        (tmp_path / "AGENTS.md").write_text("# Root\n\nKeep this.")
+
+        blocks = adapter.load(str(tmp_path))
+
+        assert len(blocks) == 1
+        assert "Keep this." in blocks[0].text
+        assert "Ignore me." not in blocks[0].text
+
+    def test_load_malformed_file_does_not_crash(
+        self, adapter: AgentsAdapter, tmp_path: Path
+    ) -> None:
+        """Should handle unexpected parse errors without crashing."""
+        (tmp_path / "AGENTS.md").write_text("# Valid\n\nKeep going.")
+
+        with patch.object(adapter, "_extract_sections", side_effect=ValueError("bad markdown")):
+            blocks = adapter.load(str(tmp_path))
+
+        assert blocks == []
+
+
+class TestAgentsAdapterProperties:
+    """Tests for adapter properties."""
+
+    def test_adapter_name(self, adapter: AgentsAdapter) -> None:
+        """Adapter name should be AGENTS.md so scan output is obvious."""
+        assert adapter.name == "AGENTS.md"
+
+    def test_is_not_experimental(self, adapter: AgentsAdapter) -> None:
+        """AGENTS.md is a stable standard adapter."""
+        assert adapter.is_experimental() is False
+
+    def test_adapter_repr(self, adapter: AgentsAdapter) -> None:
+        """Adapter repr should be informative."""
+        repr_str = repr(adapter)
+        assert "AgentsAdapter" in repr_str
+        assert "AGENTS.md" in repr_str


### PR DESCRIPTION
## Summary

Adds a stable, first-class `AGENTS.md` SpecAdapter so `specmem scan` / SpecIR treat the AAIF / Linux Foundation agent-instruction standard as a framework.

- New `AgentsAdapter` in `specmem/adapters/agents.py` (auto-discovered).
- Detects `AGENTS.md` / `Agents.md` / `AGENT.md` / `Agent.md` at the repo root or nested.
- Splits on markdown `#` / `##` / `###` headings into `SpecType.KNOWLEDGE` blocks tagged `agents` / `agents.md` plus a heading slug. A file with no headings becomes one pinned block.
- Skips junk dirs (`node_modules`, `.git`, `.venv`, …), unreadable files, and empty-ish content without crashing.
- Marked stable (`is_experimental()` is `False`). Name is `AGENTS.md` so scan output is obvious.

This is PR 1 of the adapter catch-up. It does **not** add Codex, Factory, Warp, or Gemini adapter modules.

## Why

The guidelines scanner already finds `AGENTS.md` / `AGENT.md`, but there was no SpecAdapter, so scan/SpecIR did not treat it as a framework. Codex, Factory, Warp, Cursor, OpenCode, Amp, and Aider all consume AGENTS.md.

## Docs

- README and user-guide adapters list AGENTS.md as implemented.
- Qualified the advertised-but-missing Codex / Factory / Warp / Gemini adapter claims: those tools are covered by AGENTS.md (Gemini CLI `GEMINI.md` remains guidelines-scanner only). Removed invented vendor trees (`.codex/**/*.md`, `.factory/**/*.yaml`, `.warp/**`).
- CHANGELOG `[Unreleased]` Added entry. Package version not bumped.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_agents_adapter.py -q` (24 passed)
- [x] `uv run python -m pytest tests/property/test_adapter_props.py tests/unit/test_kiro_adapter.py -q`
- [ ] `specmem scan` on a sample repo with root and nested `AGENTS.md`
- [ ] Confirm `node_modules/AGENTS.md` is ignored

Towards #11