### PR TITLE
Index Agent Skills under .agents/skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Universal Agent Skills indexer for `.agents/skills/*/SKILL.md` (primary agentskills.io root used by Codex, OpenSpec, and Gemini) and `.factory/skills/*/SKILL.md`, alongside existing `.claude/skills`. Legacy `.codex/skills` remains supported as an alias.
 - First-class AGENTS.md SpecAdapter (AAIF / Linux Foundation standard). Detects
   `AGENTS.md` / `AGENT.md` at the repo root or nested, splits on markdown
   headings into knowledge SpecBlocks, and is marked stable (not experimental).
 
 ### Changed
-- N/A
+- Agent Skills primary discovery path is now `.agents/skills`; `.codex/skills` is documented as a legacy alias.
 
 ### Deprecated
 - N/A

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ print(bundle.tldr)
 | Feature | Description |
 |---------|-------------|
 | **☁️ Cloud Embeddings** | Support for OpenAI, Google, Together AI embedding providers |
-| **📜 Coding Guidelines** | Aggregate and view guidelines from Kiro steering, CLAUDE.md, AGENTS.md, .cursorrules |
+| **📜 Coding Guidelines** | Aggregate guidelines from Kiro steering, CLAUDE.md, AGENTS.md, .cursorrules, and Agent Skills (`.agents/skills`) |
 | **🔄 Spec Lifecycle** | Prune stale specs, generate specs from code, compress verbose specs |
 | **🔍 Kiro Session Search** | Index and search Kiro chat sessions for context |
 | **⚙️ Kiro Config Indexer** | Index hooks, steering files, and MCP configurations |

--- a/docs/advanced/agent-integration.md
+++ b/docs/advanced/agent-integration.md
@@ -41,8 +41,10 @@ during `specmem scan` and `specmem build`. Supported sources include:
 | Source | Files |
 |--------|-------|
 | Generic agents | `AGENTS.md`, `AGENT.md` |
-| Codex skills | `.codex/skills/*/SKILL.md` |
+| Agent Skills | `.agents/skills/*/SKILL.md` (primary; [agentskills.io](https://agentskills.io/specification)) |
+| Factory skills | `.factory/skills/*/SKILL.md` |
 | Claude | `CLAUDE.md`, `.claude/skills/*/SKILL.md` |
+| Codex skills (legacy) | `.codex/skills/*/SKILL.md` |
 | Cursor | `.cursorrules`, `cursor.rules`, `.cursor/rules/*.mdc` |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | Gemini CLI | `GEMINI.md` |

--- a/docs/advanced/agent-memory-patterns.md
+++ b/docs/advanced/agent-memory-patterns.md
@@ -38,8 +38,10 @@ SpecMem indexes common coding-agent guidance files during `specmem scan` and
 | Source | Files |
 |--------|-------|
 | Generic agents | `AGENTS.md`, `AGENT.md` |
-| Codex skills | `.codex/skills/*/SKILL.md` |
+| Agent Skills | `.agents/skills/*/SKILL.md` (primary; [agentskills.io](https://agentskills.io/specification)) |
+| Factory skills | `.factory/skills/*/SKILL.md` |
 | Claude | `CLAUDE.md`, `.claude/skills/*/SKILL.md` |
+| Codex skills (legacy) | `.codex/skills/*/SKILL.md` |
 | Cursor | `.cursorrules`, `cursor.rules`, `.cursor/rules/*.mdc` |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | Gemini CLI | `GEMINI.md` |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Universal Agent Skills indexer for `.agents/skills/*/SKILL.md` (primary agentskills.io root used by Codex, OpenSpec, and Gemini) and `.factory/skills/*/SKILL.md`, alongside existing `.claude/skills`. Legacy `.codex/skills` remains supported as an alias.
 - First-class AGENTS.md SpecAdapter (AAIF / Linux Foundation standard). Detects
   `AGENTS.md` / `AGENT.md` at the repo root or nested, splits on markdown
   headings into knowledge SpecBlocks, and is marked stable (not experimental).
 
 ### Changed
-- N/A
+- Agent Skills primary discovery path is now `.agents/skills`; `.codex/skills` is documented as a legacy alias.
 
 ### Fixed
 - N/A

--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -35,7 +35,7 @@ The command uses `.specmem.toml` from the target repository when present.
 
 - Structured specifications from enabled adapters, such as Kiro, Spec Kit, and Tessl
 - Agent instruction files, such as `AGENTS.md`, `CLAUDE.md`, Cursor rules, and Copilot instructions
-- Agent skills from `.codex/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`
+- Agent Skills from `.agents/skills/*/SKILL.md` (primary), `.factory/skills/*/SKILL.md`, `.claude/skills/*/SKILL.md`, and legacy `.codex/skills/*/SKILL.md`
 
 Instruction files are pinned in memory by default. Skill files are indexed as
 procedural memory and selected by task intent.

--- a/docs/cli/guidelines.md
+++ b/docs/cli/guidelines.md
@@ -31,8 +31,9 @@ specmem guidelines [OPTIONS] [COMMAND]
 | `--robot`, `-r` | Output JSON for AI agents |
 | `--no-samples` | Exclude sample guidelines |
 
-Valid source types include `agents`, `claude`, `codex_skill`, `claude_skill`,
-`copilot`, `cursor`, `gemini`, `opencode`, `qwen`, and `steering`.
+Valid source types include `agents`, `agents_skill`, `factory_skill`, `claude`,
+`claude_skill`, `codex_skill` (legacy), `copilot`, `cursor`, `gemini`, `opencode`,
+`qwen`, and `steering`.
 
 ## Examples
 
@@ -47,6 +48,7 @@ specmem guidelines --source claude
 specmem guidelines --source cursor
 specmem guidelines --source steering
 specmem guidelines --source agents
+specmem guidelines --source agents_skill
 specmem guidelines --source codex_skill
 specmem guidelines --source copilot
 
@@ -222,8 +224,10 @@ SpecMem reads these agent guidance sources:
 | Source | Files |
 |--------|-------|
 | Generic agents | `AGENTS.md`, `AGENT.md` |
-| Codex skills | `.codex/skills/*/SKILL.md` |
+| Agent Skills | `.agents/skills/*/SKILL.md` (primary; [agentskills.io](https://agentskills.io/specification)) |
+| Factory skills | `.factory/skills/*/SKILL.md` |
 | Claude | `CLAUDE.md`, `.claude/skills/*/SKILL.md` |
+| Codex skills (legacy) | `.codex/skills/*/SKILL.md` |
 | Cursor | `.cursorrules`, `cursor.rules`, `.cursor/rules/*.mdc` |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | Gemini CLI | `GEMINI.md` |

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -36,8 +36,10 @@ Experience Pack and embeddings.
 | Source | Files |
 |--------|-------|
 | Generic agents | `AGENTS.md`, `AGENT.md` |
-| Codex skills | `.codex/skills/*/SKILL.md` |
+| Agent Skills | `.agents/skills/*/SKILL.md` (primary; [agentskills.io](https://agentskills.io/specification)) |
+| Factory skills | `.factory/skills/*/SKILL.md` |
 | Claude skills | `.claude/skills/*/SKILL.md` |
+| Codex skills (legacy) | `.codex/skills/*/SKILL.md` |
 | Cursor rules | `.cursorrules`, `cursor.rules`, `.cursor/rules/*.mdc` |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | Gemini CLI | `GEMINI.md` |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -258,8 +258,10 @@ SpecMem scans common coding-agent guidance files during `specmem scan` and
 | Source | Files |
 |--------|-------|
 | Generic agents | `AGENTS.md`, `AGENT.md` |
-| Codex skills | `.codex/skills/*/SKILL.md` |
+| Agent Skills | `.agents/skills/*/SKILL.md` (primary; [agentskills.io](https://agentskills.io/specification)) |
+| Factory skills | `.factory/skills/*/SKILL.md` |
 | Claude | `CLAUDE.md`, `.claude/skills/*/SKILL.md` |
+| Codex skills (legacy) | `.codex/skills/*/SKILL.md` |
 | Cursor | `.cursorrules`, `cursor.rules`, `.cursor/rules/*.mdc` |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | Gemini CLI | `GEMINI.md` |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -92,8 +92,10 @@ separate `[guidance]` section.
 | Source | Files |
 |--------|-------|
 | Generic agents | `AGENTS.md`, `AGENT.md` |
-| Codex skills | `.codex/skills/*/SKILL.md` |
+| Agent Skills | `.agents/skills/*/SKILL.md` (primary; [agentskills.io](https://agentskills.io/specification)) |
+| Factory skills | `.factory/skills/*/SKILL.md` |
 | Claude | `CLAUDE.md`, `.claude/skills/*/SKILL.md` |
+| Codex skills (legacy) | `.codex/skills/*/SKILL.md` |
 | Cursor | `.cursorrules`, `cursor.rules`, `.cursor/rules/*.mdc` |
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | Gemini CLI | `GEMINI.md` |

--- a/docs/user-guide/guidelines.md
+++ b/docs/user-guide/guidelines.md
@@ -12,8 +12,10 @@ SpecMem detects and parses guidelines from:
 | **Cursor** | `.cursorrules` | Cursor AI rules file |
 | **Kiro** | `.kiro/steering/*.md` | Kiro steering files |
 | **Agents** | `AGENTS.md` | Generic agent instructions |
-| **Codex skills** | `.codex/skills/*/SKILL.md` | Task-routed procedural skills |
-| **Claude skills** | `.claude/skills/*/SKILL.md` | Task-routed procedural skills |
+| **Agent Skills** | `.agents/skills/*/SKILL.md` | Primary Agent Skills root ([agentskills.io](https://agentskills.io/specification)); Codex / OpenSpec / Gemini |
+| **Factory skills** | `.factory/skills/*/SKILL.md` | Factory Agent Skills (+ `.agents/skills` compat) |
+| **Claude skills** | `.claude/skills/*/SKILL.md` | Claude procedural skills |
+| **Codex skills (legacy)** | `.codex/skills/*/SKILL.md` | Legacy Codex path; prefer `.agents/skills` |
 
 ## Viewing Guidelines
 

--- a/docs/user-guide/optimized-skills.md
+++ b/docs/user-guide/optimized-skills.md
@@ -190,7 +190,7 @@ source once a skill consistently improves agent behavior.
 
 ## Recommended Workflow
 
-1. Keep original skills in `.codex/skills/*/SKILL.md` or `.claude/skills/*/SKILL.md`.
+1. Keep original skills in `.agents/skills/*/SKILL.md` (primary), `.factory/skills/*/SKILL.md`, `.claude/skills/*/SKILL.md`, or legacy `.codex/skills/*/SKILL.md`.
 2. Use `specmem guidelines optimize --instruction` for small improvements.
 3. Review `.specmem/skillopt/<skill>/candidate_skill.md` when the change is important.
 4. Build with `specmem build --optimize-skills`.

--- a/specmem/cli/guidelines.py
+++ b/specmem/cli/guidelines.py
@@ -16,7 +16,7 @@ from rich.table import Table
 
 from specmem.guidelines.aggregator import GuidelinesAggregator
 from specmem.guidelines.converter import GuidelinesConverter
-from specmem.guidelines.models import Guideline, SourceType
+from specmem.guidelines.models import SKILL_SOURCE_TYPES, Guideline, SourceType
 from specmem.guidelines.optimizer import (
     OptimizedSkillStore,
     rewrite_skill_with_openai,
@@ -190,7 +190,7 @@ def optimized_status(
     skills = [
         guideline
         for guideline in response.guidelines
-        if guideline.source_type in {SourceType.CODEX_SKILL, SourceType.CLAUDE_SKILL}
+        if guideline.source_type in SKILL_SOURCE_TYPES
     ]
     store = OptimizedSkillStore(workspace_path)
     rows = [(guideline, store.status(Path(guideline.source_file))) for guideline in skills]

--- a/specmem/guidelines/__init__.py
+++ b/specmem/guidelines/__init__.py
@@ -1,6 +1,7 @@
 """Guidelines module for coding standards and rules management."""
 
 from specmem.guidelines.models import (
+    SKILL_SOURCE_TYPES,
     ConversionResult,
     Guideline,
     GuidelinesResponse,
@@ -17,6 +18,7 @@ from specmem.guidelines.optimizer import (
 
 
 __all__ = [
+    "SKILL_SOURCE_TYPES",
     "ConversionResult",
     "Guideline",
     "GuidelinesResponse",

--- a/specmem/guidelines/aggregator.py
+++ b/specmem/guidelines/aggregator.py
@@ -7,7 +7,12 @@ import logging
 from pathlib import Path
 
 from specmem.core.specir import SpecBlock, SpecStatus, SpecType
-from specmem.guidelines.models import Guideline, GuidelinesResponse, SourceType
+from specmem.guidelines.models import (
+    SKILL_SOURCE_TYPES,
+    Guideline,
+    GuidelinesResponse,
+    SourceType,
+)
 from specmem.guidelines.optimizer import OptimizedSkillStore
 from specmem.guidelines.parser import GuidelinesParser
 from specmem.guidelines.scanner import GuidelinesScanner
@@ -189,8 +194,7 @@ class GuidelinesAggregator:
                     status=SpecStatus.ACTIVE,
                     tags=list(dict.fromkeys(tags)),
                     links=[],
-                    pinned=guideline.source_type
-                    not in {SourceType.CODEX_SKILL, SourceType.CLAUDE_SKILL},
+                    pinned=guideline.source_type not in SKILL_SOURCE_TYPES,
                 )
             )
 
@@ -239,7 +243,7 @@ class GuidelinesAggregator:
         return False
 
     def _is_skill(self, guideline: Guideline) -> bool:
-        return guideline.source_type in {SourceType.CODEX_SKILL, SourceType.CLAUDE_SKILL}
+        return guideline.source_type in SKILL_SOURCE_TYPES
 
     def _matches_task(self, guideline: Guideline, task: str) -> bool:
         tokens = {token for token in re_split_words(task) if len(token) >= 3}

--- a/specmem/guidelines/models.py
+++ b/specmem/guidelines/models.py
@@ -15,13 +15,26 @@ class SourceType(StrEnum):
     CURSOR = "cursor"
     STEERING = "steering"
     AGENTS = "agents"
-    CODEX_SKILL = "codex_skill"
+    AGENTS_SKILL = "agents_skill"
+    FACTORY_SKILL = "factory_skill"
     CLAUDE_SKILL = "claude_skill"
+    CODEX_SKILL = "codex_skill"  # legacy alias for .codex/skills
     COPILOT = "copilot"
     GEMINI = "gemini"
     OPENCODE = "opencode"
     QWEN = "qwen"
     SAMPLE = "sample"
+
+
+# Procedural Agent Skills (SKILL.md) sources used by scanner/parser/aggregator.
+SKILL_SOURCE_TYPES: frozenset[SourceType] = frozenset(
+    {
+        SourceType.AGENTS_SKILL,
+        SourceType.FACTORY_SKILL,
+        SourceType.CLAUDE_SKILL,
+        SourceType.CODEX_SKILL,  # legacy .codex/skills alias
+    }
+)
 
 
 @dataclass

--- a/specmem/guidelines/parser.py
+++ b/specmem/guidelines/parser.py
@@ -39,10 +39,19 @@ class GuidelinesParser:
             return self.parse_steering(file_path)
         elif source_type == "agents":
             return self.parse_agents(file_path)
-        elif source_type == "codex_skill":
-            return self.parse_skill(file_path, SourceType.CODEX_SKILL, ["codex", "skill"])
+        elif source_type == "agents_skill":
+            return self.parse_skill(
+                file_path, SourceType.AGENTS_SKILL, ["agents", "skill", "agentskills"]
+            )
+        elif source_type == "factory_skill":
+            return self.parse_skill(
+                file_path, SourceType.FACTORY_SKILL, ["factory", "skill", "agentskills"]
+            )
         elif source_type == "claude_skill":
             return self.parse_skill(file_path, SourceType.CLAUDE_SKILL, ["claude", "skill"])
+        elif source_type == "codex_skill":
+            # Legacy .codex/skills path; prefer .agents/skills
+            return self.parse_skill(file_path, SourceType.CODEX_SKILL, ["codex", "skill"])
         elif source_type == "copilot":
             return self.parse_markdown_file(
                 file_path, SourceType.COPILOT, ["copilot", "instructions"]

--- a/specmem/guidelines/scanner.py
+++ b/specmem/guidelines/scanner.py
@@ -17,8 +17,10 @@ class GuidelinesScanner:
     - AGENTS.md (Generic agent instructions)
     - .cursorrules (Cursor)
     - .cursor/rules/*.mdc (Cursor project rules)
-    - .codex/skills/*/SKILL.md (Codex skills)
+    - .agents/skills/*/SKILL.md (Agent Skills primary root / agentskills.io)
+    - .factory/skills/*/SKILL.md (Factory Agent Skills)
     - .claude/skills/*/SKILL.md (Claude skills)
+    - .codex/skills/*/SKILL.md (legacy Codex skills alias)
     - .github/copilot-instructions.md and .github/instructions/*.instructions.md
     - GEMINI.md, OPENCODE.md, QWEN.md
     - .kiro/steering/*.md (Kiro steering files)
@@ -29,8 +31,13 @@ class GuidelinesScanner:
         "agents": ["**/AGENTS.md", "**/Agents.md", "**/AGENT.md", "**/Agent.md"],
         "cursor": ["**/.cursorrules", "**/cursor.rules", "**/.cursor/rules/*.mdc"],
         "steering": [".kiro/steering/*.md"],
-        "codex_skill": ["**/.codex/skills/*/SKILL.md"],
+        # Agent Skills (https://agentskills.io/specification) — primary Codex /
+        # OpenSpec / Gemini path is .agents/skills; Factory uses .factory/skills
+        # (+ .agents/skills compat). .codex/skills remains a legacy alias only.
+        "agents_skill": ["**/.agents/skills/*/SKILL.md"],
+        "factory_skill": ["**/.factory/skills/*/SKILL.md"],
         "claude_skill": ["**/.claude/skills/*/SKILL.md"],
+        "codex_skill": ["**/.codex/skills/*/SKILL.md"],  # legacy alias
         "copilot": [
             "**/.github/copilot-instructions.md",
             "**/.github/instructions/*.instructions.md",

--- a/tests/unit/test_agent_guidance_memory.py
+++ b/tests/unit/test_agent_guidance_memory.py
@@ -262,3 +262,133 @@ def test_instruction_generated_candidate_accepts_static_non_regression(tmp_path:
 
     assert "Retrieval Notes" in blocks[0].text
     assert any(tag.startswith("skillopt:score:") for tag in blocks[0].tags)
+
+def test_scanner_finds_agents_skills_primary_root(tmp_path: Path) -> None:
+    """A fixture with ONLY .agents/skills discovers Agent Skills."""
+    skill_dir = tmp_path / ".agents" / "skills" / "foo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: foo\n"
+        "description: Do the foo workflow\n"
+        "---\n"
+        "# Foo\n\nRun the foo steps carefully."
+    )
+
+    scanned = GuidelinesScanner(tmp_path).scan()
+
+    assert list(scanned.keys()) == ["agents_skill"]
+    assert len(scanned["agents_skill"]) == 1
+    assert scanned["agents_skill"][0].name == "SKILL.md"
+
+
+def test_scanner_finds_factory_skills(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".factory" / "skills" / "ship"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: ship\ndescription: Ship a change\n---\n# Ship\n\nOpen a PR."
+    )
+
+    scanned = GuidelinesScanner(tmp_path).scan()
+
+    assert "factory_skill" in scanned
+    assert len(scanned["factory_skill"]) == 1
+
+
+def test_scanner_empty_repo_has_no_false_positive_skills(tmp_path: Path) -> None:
+    scanned = GuidelinesScanner(tmp_path).scan()
+
+    assert scanned == {}
+    assert GuidelinesScanner(tmp_path).has_guidelines() is False
+
+
+def test_parser_preserves_agents_skill_frontmatter(tmp_path: Path) -> None:
+    skill_file = tmp_path / ".agents" / "skills" / "foo" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    skill_file.write_text(
+        "---\n"
+        "name: foo\n"
+        "description: Do the foo workflow\n"
+        "---\n"
+        "# Steps\n\nExecute carefully."
+    )
+
+    guidelines = GuidelinesParser().parse_file(skill_file, "agents_skill")
+
+    assert len(guidelines) == 1
+    assert guidelines[0].source_type == SourceType.AGENTS_SKILL
+    assert guidelines[0].title == "foo"
+    assert guidelines[0].content.startswith("Do the foo workflow")
+    assert "Execute carefully" in guidelines[0].content
+    assert "agentskills" in guidelines[0].tags
+
+
+def test_legacy_codex_skills_still_discovered(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".codex" / "skills" / "legacy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: legacy\ndescription: Legacy path\n---\n# Legacy\n\nStill works."
+    )
+
+    scanned = GuidelinesScanner(tmp_path).scan()
+    guidelines = GuidelinesAggregator(tmp_path).get_all(include_samples=False).guidelines
+
+    assert "codex_skill" in scanned
+    assert len(guidelines) == 1
+    assert guidelines[0].source_type == SourceType.CODEX_SKILL
+    assert guidelines[0].title == "legacy"
+
+
+def test_agents_skills_flow_into_context_and_spec_blocks(tmp_path: Path) -> None:
+    skill = tmp_path / ".agents" / "skills" / "qdrant-memory" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\n"
+        "name: qdrant-memory\n"
+        "description: Design Qdrant memory retrieval for coding agents\n"
+        "---\n"
+        "# Workflow\n\nUse payload filters."
+    )
+
+    aggregator = GuidelinesAggregator(tmp_path)
+    context = aggregator.build_context(task="improve qdrant memory retrieval")
+    blocks = aggregator.to_spec_blocks()
+
+    assert [g.source_type for g in context["skills"]] == [SourceType.AGENTS_SKILL]
+    assert len(blocks) == 1
+    assert "agents_skill" in blocks[0].tags
+    assert blocks[0].pinned is False
+
+
+def test_optimize_skills_works_with_agents_skills_root(tmp_path: Path) -> None:
+    skill = tmp_path / ".agents" / "skills" / "review" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review code changes\n"
+        "---\n"
+        "# Review\n\nFind regressions."
+    )
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text(
+        "# Review\n\n"
+        "Find regressions.\n\n"
+        "## Evidence\n\n"
+        "Check failing tests, changed call sites, and backwards compatibility notes."
+    )
+
+    result = OptimizedSkillStore(tmp_path).promote_candidate(
+        skill,
+        candidate,
+        score_before=0.2,
+        score_after=0.9,
+        evaluator="unit",
+    )
+    assert result.accepted
+
+    blocks = GuidelinesAggregator(tmp_path).to_spec_blocks(optimize_skills=True)
+
+    assert "backwards compatibility notes" in blocks[0].text
+    assert "optimized-skill" in blocks[0].tags
+


### PR DESCRIPTION
## Summary

Indexes [Agent Skills](https://agentskills.io/specification) (`SKILL.md`) into SpecMem guidelines / memory the same way existing skill paths already work.

- **Primary root:** `.agents/skills/*/SKILL.md` (Codex / OpenSpec / Gemini converging path)
- **Factory:** `.factory/skills/*/SKILL.md`
- **Claude:** `.claude/skills/*/SKILL.md` (unchanged)
- **Legacy alias:** `.codex/skills/*/SKILL.md` (kept; documented as legacy)

Extends `SourceType` with `agents_skill` / `factory_skill`, wires them through scanner → parser → aggregator → `optimized-status` / `--optimize-skills`, and shares a `SKILL_SOURCE_TYPES` set so skill routing stays consistent.

No version bump, PyPI publish, OpenSpec/Cursor adapter work, or MCP rewrite.

## Roots added

| Root | Source type | Notes |
|------|-------------|-------|
| `.agents/skills/*/SKILL.md` | `agents_skill` | Primary Agent Skills root |
| `.factory/skills/*/SKILL.md` | `factory_skill` | Factory layout |
| `.claude/skills/*/SKILL.md` | `claude_skill` | Existing |
| `.codex/skills/*/SKILL.md` | `codex_skill` | Legacy alias only |

## Test plan

- [x] `pytest tests/unit/test_agent_guidance_memory.py` — includes new coverage for:
  - fixture with **only** `.agents/skills/foo/SKILL.md` discovered
  - frontmatter `name` / `description` preserved
  - `.factory/skills` discovered
  - legacy `.codex/skills` still works
  - empty repo does not false-positive
  - agents skills flow into context / SpecBlocks / `--optimize-skills`
- [x] `pytest tests/property/test_guidelines_props.py`

Towards #11